### PR TITLE
Création du template pour le panel admin

### DIFF
--- a/controller/controller_signalement.class.php
+++ b/controller/controller_signalement.class.php
@@ -13,7 +13,7 @@
  * 
  * @author Sylvain Trouilh <strouilh@iutbayonne.unniv-pau.fr>
  */
-class ControllerSignalement extends Controller
+class ControllerDashboard extends Controller
 {
     /**
      * @brief Constructeur de la classe ControllerSignalement
@@ -93,6 +93,24 @@ class ControllerSignalement extends Controller
 
         // Redirection vers la page des signalements
         $this->afficheSignalements();
+    }
+
+
+    // Fonctions à compléter
+    function afficherUtilisateurs(?string $eventuelsFiltres){
+
+    }
+
+    function afficherAdministration(){
+
+    }
+
+    function bannirUtilisateur(?string $idUtilisateur){
+
+    }
+
+    function debannirUtilisateur(?string $idUtilisateur){
+
     }
 
 }

--- a/templates/base_template.html.twig
+++ b/templates/base_template.html.twig
@@ -125,8 +125,8 @@ f.parentNode.insertBefore(j, f);
 						</a>
 
 						{% if utilisateurConnecte is not null and utilisateurConnecte.getRole().toString() == "Moderateur" %}
-							<a href="index.php?controller=signalement&methode=afficheSignalements">
-								<button class="btn btn-myprimary">signalement</button>
+							<a href="index.php?controller=dashboard&methode=afficheSignalements">
+								<button class="btn btn-myprimary">Dashboard</button>
 							</a>
 						{% endif %}
 

--- a/templates/pageAdministration.html.twig
+++ b/templates/pageAdministration.html.twig
@@ -1,0 +1,10 @@
+{% extends 'templateAdmin.html.twig' %}
+
+{% block admin %}
+    border-bottom border-2 border-dark
+{% endblock %}
+
+
+{% block pageContent %}
+
+{% endblock %}

--- a/templates/pageUtilisateursAdmin.html.twig
+++ b/templates/pageUtilisateursAdmin.html.twig
@@ -1,0 +1,10 @@
+{% extends 'templateAdmin.html.twig' %}
+
+{% block users %}
+    border-bottom border-2 border-dark
+{% endblock %}
+
+
+{% block pageContent %}
+
+{% endblock %}

--- a/templates/signalement.html.twig
+++ b/templates/signalement.html.twig
@@ -1,6 +1,10 @@
-{% extends "base_template.html.twig" %}
+{% extends "templateAdmin.html.twig" %}
 
-{% block content %}
+{% block signalement %}
+    border-bottom border-2 border-dark
+{% endblock %}
+
+{% block pageContent %}
 
 <main class="  flex-grow-1">
 

--- a/templates/signalement.html.twig
+++ b/templates/signalement.html.twig
@@ -7,30 +7,23 @@
 {% block pageContent %}
 
 <main class="  flex-grow-1">
-
-<div class=" container  my-4  bg-mydark text-white rounded">
-
+    <div class=" container  my-4  bg-mydark text-white rounded">
             {% if signalements  is null %}
 			<div class="py-2   d-flex align-items-center">
-
-				<p class="col-7 col-md-9 mb-1 ">il y a aucun sigalemen</p>
+				<p class="col-7 col-md-9 mb-1 ">il n'y a aucun sigalement pour le moment.</p>
             </div>
             {% else %}
-                
                 <div class="py-2 border-primary row border-bottom border-1  d-flex align-items-center">
                     <p class="col-7 col-md-9 mb-1 ">il y a {{ nbSignalements }} signalements</p>
-                    
                 </div>
                 <div class="py-2 row border-primary border-bottom border-1  d-flex align-items-center">
-                    <p class="mb-0 col-4 col-md-6 border-primary border-end border-1"> contenu du message </p>
-                    <p class="mb-0 col-2  border-primary border-end border-1">raison(s)</p>
-                    <p class="mb-0 col-2 ">nombre de signalement </p>
-                    
+                    <p class="mb-0 col-4 col-md-6 border-primary border-end border-1"> Contenu du message </p>
+                    <p class="mb-0 col-2  border-primary border-end border-1">Raison(s)</p>
+                    <p class="mb-0 col-2 ">Nombre de signalements </p>
                 </div>
-
                 {% for signalement in signalements %}
                     <div class=" py-2 ">
-                        <form action="index.php?controller=signalement&methode=supprimerMessageSignale" method="post" class="row">
+                        <form action="index.php?controller=dashboard&methode=supprimerMessageSignale" method="post" class="row">
                             <input type="hidden" name="idMessage" value="{{signalement.idMessage}}">
                             <a href="index.php?controller=fil&methode=afficherFilParId&id_fil={{signalement.idFil}}#{{signalement.idMessage}}" class="my-auto col-4 col-md-6  border-primary border-end border-1">{{signalement.valeur}}</a>
                             <p class="mb-0 col-2  border-primary border-end border-1">{{signalement.raisons}}</p>

--- a/templates/templateAdmin.html.twig
+++ b/templates/templateAdmin.html.twig
@@ -1,0 +1,24 @@
+{% extends 'base_template.html.twig' %}
+
+{% block content %}
+    <div class="row row-cols-sm-3 row-cols-1 w-75 mx-auto mt-5">
+        <div>
+            <a href="index.php?controller=dashboard&methode=afficherSignalements" class="btn btn-primary border {% block signalement %}  {% endblock %} w-100 mb-2">Signalements</a>
+        </div>
+        <div>
+            <a href="index.php?controller=dashboard&methode=afficherUtilisateurs" class="btn btn-primary {% block users %}  {% endblock %}  w-100 mb-2">Utilisateurs</a>
+        </div>
+        <div>
+            <a href="index.php?controller=dashboard&methode=administration" class="btn btn-primary {% block admin %} {% endblock %}   w-100 mb-2">Administration</a>
+        </div>
+    </div>
+
+
+    {% block pageContent %}
+
+
+    {% endblock %}
+
+
+
+{% endblock %}


### PR DESCRIPTION
Nouvelles features : 
- Ajout d'un template pour le panel admin (sur le modèle de celui de la page de profil et de la maquette)
- ControllerSignalements -> ControllerDashboard
- Changement du texte du bouton d'accès au dashboard (signalement -> Dashboard)
- Correction fautes d'orthographe panel de signalements
- Mise en place de tous les fichiers twig pour le panel admin COMPLET