### PR TITLE
Refonte des messages d'erreur et ajout des messages de succès

### DIFF
--- a/JS/toasts.js
+++ b/JS/toasts.js
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", function () {
+    var toastEl = document.querySelector(".toast");
+    if (toastEl) {
+        var toast = new bootstrap.Toast(toastEl);
+        toast.show();
+    }
+});

--- a/controller/controller_fil.class.php
+++ b/controller/controller_fil.class.php
@@ -59,7 +59,7 @@ class ControllerFil extends Controller
      *
      * @return void
      */
-    public function afficherFilParId(?int $idFil = null, ?string $messageErreur = null)
+    public function afficherFilParId(?int $idFil = null, ?bool $indiqueSuccess = null, ?string $message = null)
     {
         if($idFil === null) {
             $idFil = $_GET['id_fil'];
@@ -89,7 +89,8 @@ class ControllerFil extends Controller
             'messages' => $messages,
             'page_courante' => $page,
             'nombre_pages' => $nombrePages,
-            'messageErreur' => $messageErreur,
+            'indiqueSuccess' => $indiqueSuccess,
+            'messageInfos' => $message,
             'raisonsSignalement' => $raisonsSignalement
         ]);
         exit();
@@ -124,7 +125,7 @@ class ControllerFil extends Controller
         $contenuErreur = "Un message doit contenir";
         $messageEstValide = Utilitaires::comprisEntre($message, 1024, 10, $contenuErreur, $messageErreur);
         if (!$messageEstValide) {
-            $this->afficherFilParId($idFil, $messageErreur);
+            $this->afficherFilParId($idFil, false, $messageErreur);
             exit();
         }
 
@@ -132,20 +133,20 @@ class ControllerFil extends Controller
         $messageEstProfane = Utilitaires::verificationDeNom($message, "Le message ", $messageErreur);
         if ($messageEstProfane) {
             $this->signalerMessage($message);
-            $this->afficherFilParId($idFil, $messageErreur);
+            $this->afficherFilParId($idFil, false, $messageErreur);
             exit();
         }
 
         // Vérifier et convertir l'ID du fil
         if ($idFil === 0) {
-            $this->afficherFilParId($idFil, "ID de fil invalide");
+            $this->afficherFilParId($idFil, false, "ID de fil invalide");
             exit();
         }
 
         // Récupérer l'ID du message parent (si présent)
         $idMessageParent = isset($_POST['id_message_parent']) ? intval($_POST['id_message_parent']) : null;
         if (isset($_POST['id_message_parent']) && $idMessageParent === 0) {
-            $this->afficherFilParId($idFil, "ID de message parent invalide");
+            $this->afficherFilParId($idFil, false, "ID de message parent invalide");
             exit();
         }
 
@@ -361,7 +362,7 @@ class ControllerFil extends Controller
         $indiquePropriete = $managerMessage->checkProprieteMessage($idMessageASuppr, $idUtilisateur);
 
         if (!$indiquePropriete) {
-            $this->afficherFilParId($idFil, "Vous ne pouvez pas supprimer ce message, il ne vous appartient pas");
+            $this->afficherFilParId($idFil, true, "Vous ne pouvez pas supprimer ce message, il ne vous appartient pas");
             exit();
         }
 
@@ -410,7 +411,7 @@ class ControllerFil extends Controller
 
             // Vérifier la raison
             if (!RaisonSignalement::isValidReason($raison)) {
-                $this->afficherFilParId($idFil, "Raison de signalement invalide");
+                $this->afficherFilParId($idFil, false, "Raison de signalement invalide");
                 exit();
             }
         } else {
@@ -520,7 +521,7 @@ class ControllerFil extends Controller
             if ($idFil === null) {
                 $this->listerThreads("Méthode HTTP invalide");
             } else {
-                $this->afficherFilParId($idFil, "Méthode HTTP invalide");
+                $this->afficherFilParId($idFil, false, "Méthode HTTP invalide");
             }
             exit();
         }
@@ -543,7 +544,7 @@ class ControllerFil extends Controller
             // Renvoyer la bonne vue en cas d'erreur
             switch ($source) {
                 case "thread":
-                    $this->afficherFilParId($idFil, "Vous devez être connecté pour signaler un message");
+                    $this->afficherFilParId($idFil, false, "Vous devez être connecté pour effectuer cette action !");
                     break;
                 case "forum":
                     $this->listerThreads("Vous devez être connecté pour signaler un message");

--- a/controller/controller_fil.class.php
+++ b/controller/controller_fil.class.php
@@ -60,41 +60,48 @@ class ControllerFil extends Controller
      * @return void
      */
     public function afficherFilParId(?int $idFil = null, ?bool $indiqueSuccess = null, ?string $message = null)
-    {
-        if($idFil === null) {
-            $idFil = $_GET['id_fil'];
-        }
-        $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
-        $messagesParPage = NOMBRE_MESSAGES_PAR_PAGE;
-
-        // Récupérer le fil
-        $filDAO = new FilDAO($this->getPdo());
-        $fil = $filDAO->findById($idFil);
-
-        // Récupérer les messages paginés
-        $messageDAO = new MessageDAO($this->getPdo());
-        $messages = $messageDAO->getMessagesPagines($idFil, $page, $messagesParPage);
-
-        // Calculer le nombre total de pages
-        $totalMessages = $messageDAO->getNombreMessagesParent($idFil);
-        $nombrePages = ceil($totalMessages / $messagesParPage);
-
-        // Récupérer les raisons de signalement
-        $signalementDAO = new SignalementDAO($this->getPdo());
-        $raisonsSignalement = RaisonSignalement::getAllReasons();
-
-        // Passer les données à la vue
-        echo $this->getTwig()->render('fil.html.twig', [
-            'fil' => $fil,
-            'messages' => $messages,
-            'page_courante' => $page,
-            'nombre_pages' => $nombrePages,
-            'indiqueSuccess' => $indiqueSuccess,
-            'messageInfos' => $message,
-            'raisonsSignalement' => $raisonsSignalement
-        ]);
-        exit();
+{
+    if ($idFil === null) {
+        $idFil = $_GET['id_fil'];
     }
+    $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
+    $messagesParPage = NOMBRE_MESSAGES_PAR_PAGE;
+
+    // Récupérer le fil
+    $filDAO = new FilDAO($this->getPdo());
+    $fil = $filDAO->findById($idFil);
+
+    // Récupérer les messages paginés
+    $messageDAO = new MessageDAO($this->getPdo());
+    $messages = $messageDAO->getMessagesPagines($idFil, $page, $messagesParPage);
+
+    // Calculer le nombre total de pages
+    $totalMessages = $messageDAO->getNombreMessagesParent($idFil);
+    $nombrePages = ceil($totalMessages / $messagesParPage);
+
+    // Récupérer les raisons de signalement
+    $raisonsSignalement = RaisonSignalement::getAllReasons();
+
+    // Préparer les données à passer à la vue, en excluant les variables nulles
+    $data = [
+        'fil' => $fil,
+        'messages' => $messages,
+        'page_courante' => $page,
+        'nombre_pages' => $nombrePages,
+        'raisonsSignalement' => $raisonsSignalement
+    ];
+
+    // Ajouter conditionnellement les variables si elles ne sont pas nulles
+    if ($indiqueSuccess !== null) {
+        $data['indiqueSuccess'] = $indiqueSuccess;
+        $data['messageInfos'] = $message;
+    }
+
+    // Passer les données à la vue
+    echo $this->getTwig()->render('fil.html.twig', $data);
+    exit();
+}
+
 
     /**
      * @brief Méthode d'ajout d'un message (avec ou sans message parent) dans un fil de discussion

--- a/templates/fil.html.twig
+++ b/templates/fil.html.twig
@@ -116,31 +116,6 @@
 				{% endfor %}
 			</div>
 		</div>
-
-		<!-- Message d'erreur -->
-		{% if not indiqueSuccess %}
-			<div class="toast-container position-fixed bottom-0 end-0 p-3">
-				<div class="toast align-items-center text-bg-danger border-0" role="alert" aria-live="assertive" aria-atomic="true">
-					<div class="d-flex">
-						<div class="toast-body">
-							{{ messageInfos }}
-						</div>
-						<button type="button" class="btn-close me-2 m-auto btn-white" data-bs-dismiss="toast" aria-label="Close"></button>
-					</div>
-				</div>
-			</div>
-			{% else %}
-			<div class="toast-container position-fixed top-0 end-0 p-3">
-				<div class="toast align-items-center text-bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true">
-					<div class="d-flex">
-						<div class="toast-body">
-							{{ messageInfos }}
-						</div>
-						<button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
-					</div>
-				</div>
-			</div>
-		{% endif %}
 	
 		<!-- Conteneur de message -->
 		<div class="container mt-3" id="messageContainer">
@@ -387,7 +362,25 @@
 		</nav>
 
 		
-
+		<!-- Message d'erreur -->
+		{% if indiqueSuccess is not null %}
+			<div class="toast-container position-fixed bottom-0 end-0 p-3">
+				<div class="toast align-items-center 
+						{% if indiqueSuccess == false %}
+							text-bg-danger
+						{% else %}
+							text-bg-success
+						{% endif %}
+							border-0" role="alert" aria-live="assertive" aria-atomic="true">
+					<div class="d-flex">
+						<div class="toast-body">
+							{{ messageInfos }}
+						</div>
+						<button type="button" class="btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+					</div>
+				</div>
+			</div>
+		{% endif %}
 	</main>
 
 	<script src="JS/thread.js"></script>

--- a/templates/fil.html.twig
+++ b/templates/fil.html.twig
@@ -376,7 +376,7 @@
 						<div class="toast-body">
 							{{ messageInfos }}
 						</div>
-						<button type="button" class="btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+						<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
 					</div>
 				</div>
 			</div>

--- a/templates/fil.html.twig
+++ b/templates/fil.html.twig
@@ -118,118 +118,136 @@
 		</div>
 
 		<!-- Message d'erreur -->
-		{% if messageErreur is not null %}
-			<div class="alert alert-danger alert-dismissible fade show text-center" role="alert" style="background-color: #dc3545; color: white;">
-				{{ messageErreur }}
-				<button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert" aria-label="Close"></button>
+		{% if not indiqueSuccess %}
+			<div class="toast-container position-fixed bottom-0 end-0 p-3">
+				<div class="toast align-items-center text-bg-danger border-0" role="alert" aria-live="assertive" aria-atomic="true">
+					<div class="d-flex">
+						<div class="toast-body">
+							{{ messageInfos }}
+						</div>
+						<button type="button" class="btn-close me-2 m-auto btn-white" data-bs-dismiss="toast" aria-label="Close"></button>
+					</div>
+				</div>
+			</div>
+			{% else %}
+			<div class="toast-container position-fixed top-0 end-0 p-3">
+				<div class="toast align-items-center text-bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true">
+					<div class="d-flex">
+						<div class="toast-body">
+							{{ messageInfos }}
+						</div>
+						<button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+					</div>
+				</div>
 			</div>
 		{% endif %}
-
+	
+		<!-- Conteneur de message -->
 		<div class="container mt-3" id="messageContainer">
 			{% for message in messages %}
-    {% if message.idMessageParent is null %}
-        <div id="{{message.getIdMessage()}}" class="card my-4 shadow-sm border-0 rounded-3">
-            <div class="card-body p-4 bg-mydark text-white rounded">
-                <div class="d-flex align-items-center">
-                    <img src="{{ message.getUtilisateur() ? message.getUtilisateur().getUrlImageProfil() : 'default_avatar.jpg' }}" alt="Avatar" class="rounded-circle me-3" width="50" height="50">
-                    <div class="d-flex align-items-center">
-                        <h5 class="mb-0 mx-2 username-link">
-                            <a href="index.php?controller=utilisateur&methode=show&id_utilisateur={{message.getUtilisateur().getId() }}" style="color:white;" class="text-decoration-none">
-                                {{ message.getUtilisateur().getPseudo() ?: 'Utilisateur inconnu' }}
-                            </a>
-                        </h5>
-                        <span class="mx-2" style="font-size: 1.2em;">•</span>
-                        <small>{{ message.dateC | date('d M Y') }}</small>
-                    </div>
-                </div>
-                <div class="message" data-id-message="{{ message.getIdMessage() }}">
-                    <p class="message-text">
-                        {% if message.valeur == messageSuppr and message.getUtilisateur().getPseudo() is null %}
-                            <i>{{ message.valeur }}</i>
-                        {% else %}
-                            {{ message.valeur }}
-                        {% endif %}
-                    </p>
-                </div>
-                <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between w-100">
-                    {% if utilisateurConnecte is null %}
-                        <!-- Bouton "se connecter" -->
-                        <div class="d-flex flex-wrap gap-2">
-                            <a href="index.php?controller=utilisateur&methode=connexion" class="btn action-btn">
-                                <i class="bi bi-box-arrow-in-right"></i>
-                                <span class="btn-text">Se connecter</span>
-                            </a>
-                        </div>
-                    {% else %}
-                        <!-- Boutons like, dislike, répondre -->
-                        <div class="d-flex flex-wrap gap-2 likesContainer" data-message-id="{{ message.getIdMessage() }}">
-                            <form method="POST" action="index.php?controller=fil&methode=like">
-                                <input type="hidden" name="id_message" value="{{ message.getIdMessage() }}">
-                                <input type="hidden" name="id_fil" value="{{ fil.0.getId() }}">
-                                <button class="btn action-btn" type="submit" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
-                                    <i class="bi bi-hand-thumbs-up"></i>
-                                    {% if message.nbLikes > 0 %}
-                                        <span class="count">{{ message.nbLikes }}</span>
-                                    {% endif %}
-                                </button>
-                            </form>
+				{% if message.idMessageParent is null %}
+					<div id="{{message.getIdMessage()}}" class="card my-4 shadow-sm border-0 rounded-3">
+						<div class="card-body p-4 bg-mydark text-white rounded">
+							<div class="d-flex align-items-center">
+								<img src="{{ message.getUtilisateur() ? message.getUtilisateur().getUrlImageProfil() : 'default_avatar.jpg' }}" alt="Avatar" class="rounded-circle me-3" width="50" height="50">
+								<div class="d-flex align-items-center">
+									<h5 class="mb-0 mx-2 username-link">
+										<a href="index.php?controller=utilisateur&methode=show&id_utilisateur={{message.getUtilisateur().getId() }}" style="color:white;" class="text-decoration-none">
+											{{ message.getUtilisateur().getPseudo() ?: 'Utilisateur inconnu' }}
+										</a>
+									</h5>
+									<span class="mx-2" style="font-size: 1.2em;">•</span>
+									<small>{{ message.dateC | date('d M Y') }}</small>
+								</div>
+							</div>
+							<div class="message" data-id-message="{{ message.getIdMessage() }}">
+								<p class="message-text">
+									{% if message.valeur == messageSuppr and message.getUtilisateur().getPseudo() is null %}
+										<i>{{ message.valeur }}</i>
+									{% else %}
+										{{ message.valeur }}
+									{% endif %}
+								</p>
+							</div>
+							<div class="d-flex flex-wrap gap-2 align-items-center justify-content-between w-100">
+								{% if utilisateurConnecte is null %}
+									<!-- Bouton "se connecter" -->
+									<div class="d-flex flex-wrap gap-2">
+										<a href="index.php?controller=utilisateur&methode=connexion" class="btn action-btn">
+											<i class="bi bi-box-arrow-in-right"></i>
+											<span class="btn-text">Se connecter</span>
+										</a>
+									</div>
+								{% else %}
+									<!-- Boutons like, dislike, répondre -->
+									<div class="d-flex flex-wrap gap-2 likesContainer" data-message-id="{{ message.getIdMessage() }}">
+										<form method="POST" action="index.php?controller=fil&methode=like">
+											<input type="hidden" name="id_message" value="{{ message.getIdMessage() }}">
+											<input type="hidden" name="id_fil" value="{{ fil.0.getId() }}">
+											<button class="btn action-btn" type="submit" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
+												<i class="bi bi-hand-thumbs-up"></i>
+												{% if message.nbLikes > 0 %}
+													<span class="count">{{ message.nbLikes }}</span>
+												{% endif %}
+											</button>
+										</form>
 
-                            <form method="POST" action="index.php?controller=fil&methode=dislike">
-                                <input type="hidden" name="id_message" value="{{ message.getIdMessage() }}">
-                                <input type="hidden" name="id_fil" value="{{ fil.0.getId() }}">
-                                <button class="btn action-btn" type="submit" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
-                                    <i class="bi bi-hand-thumbs-down"></i>
-                                    {% if message.nbDislikes > 0 %}
-                                        <span class="count">{{ message.nbDislikes }}</span>
-                                    {% endif %}
-                                </button>
-                            </form>
+										<form method="POST" action="index.php?controller=fil&methode=dislike">
+											<input type="hidden" name="id_message" value="{{ message.getIdMessage() }}">
+											<input type="hidden" name="id_fil" value="{{ fil.0.getId() }}">
+											<button class="btn action-btn" type="submit" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
+												<i class="bi bi-hand-thumbs-down"></i>
+												{% if message.nbDislikes > 0 %}
+													<span class="count">{{ message.nbDislikes }}</span>
+												{% endif %}
+											</button>
+										</form>
 
-                            <button class="btn action-btn" data-bs-toggle="modal" data-bs-target="#repondreModal" data-id-message-parent="{{ message.getIdMessage() }}" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
-                                <i class="bi bi-reply"></i>
-                                <span class="btn-text">Répondre</span>
-                            </button>
-                        </div>
+										<button class="btn action-btn" data-bs-toggle="modal" data-bs-target="#repondreModal" data-id-message-parent="{{ message.getIdMessage() }}" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
+											<i class="bi bi-reply"></i>
+											<span class="btn-text">Répondre</span>
+										</button>
+									</div>
 
-                        <!-- Afficheur de réponses -->
-                        <div class="tooglerReponses mt-3" data-message-id="{{ message.getIdMessage() }}">
-                            {% if message.reponses is not empty %}
-                                <span class="toggle-responses text-light my-2" data-message-id="{{ message.getIdMessage() }}">
-                                    <i class="bi bi-chevron-down"></i>
-                                    <span class="show-text">Voir les réponses</span>
-                                    <span class="hide-text" style="display: none;">Masquer les réponses</span>
-                                </span>
-                            {% endif %}
-                        </div>
+									<!-- Afficheur de réponses -->
+									<div class="tooglerReponses mt-3" data-message-id="{{ message.getIdMessage() }}">
+										{% if message.reponses is not empty %}
+											<span class="toggle-responses text-light my-2" data-message-id="{{ message.getIdMessage() }}">
+												<i class="bi bi-chevron-down"></i>
+												<span class="show-text">Voir les réponses</span>
+												<span class="hide-text" style="display: none;">Masquer les réponses</span>
+											</span>
+										{% endif %}
+									</div>
 
-                        <!-- Boutons supprimer/signaler -->
-                        <div class="d-flex gap-2">
-                            {% if (message.getUtilisateur().getId() == utilisateurConnecte.getId()) or (utilisateurConnecte.getRoleAsString() == "Moderateur") %}
-                                <form method="POST" action="index.php?controller=fil&methode=supprimerMessage" onsubmit="return confirmerSuppression('{{ message.getIdMessage() }}');">
-                                    <input type="hidden" name="idMessage" value="{{ message.getIdMessage() }}">
-                                    <input type="hidden" name="id_fil" value="{{ fil.0.getId() }}">
-                                    <button class="btn action-btn warning-btn" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
-                                        <i class="bi bi-trash"></i>
-                                        <span class="btn-text">Supprimer</span>
-                                    </button>
-                                </form>
-                            {% else %}
-                                <button class="btn action-btn warning-btn" data-bs-toggle="modal" data-bs-target="#signalement" data-id-message="{{ message.getIdMessage() }}" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
-                                    <i class="bi bi-flag"></i>
-                                    <span class="btn-text">Signaler</span>
-                                </button>
-                            {% endif %}
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
+									<!-- Boutons supprimer/signaler -->
+									<div class="d-flex gap-2">
+										{% if (message.getUtilisateur().getId() == utilisateurConnecte.getId()) or (utilisateurConnecte.getRoleAsString() == "Moderateur") %}
+											<form method="POST" action="index.php?controller=fil&methode=supprimerMessage" onsubmit="return confirmerSuppression('{{ message.getIdMessage() }}');">
+												<input type="hidden" name="idMessage" value="{{ message.getIdMessage() }}">
+												<input type="hidden" name="id_fil" value="{{ fil.0.getId() }}">
+												<button class="btn action-btn warning-btn" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
+													<i class="bi bi-trash"></i>
+													<span class="btn-text">Supprimer</span>
+												</button>
+											</form>
+										{% else %}
+											<button class="btn action-btn warning-btn" data-bs-toggle="modal" data-bs-target="#signalement" data-id-message="{{ message.getIdMessage() }}" {% if message.valeur == messageSuppr or utilisateurConnecte is null %} disabled {% endif %}>
+												<i class="bi bi-flag"></i>
+												<span class="btn-text">Signaler</span>
+											</button>
+										{% endif %}
+									</div>
+								{% endif %}
+							</div>
+						</div>
+					</div>
 
-        <div class="responses-container" style="display: none;" data-message-id="{{ message.getIdMessage() }}">
-            {{ macros.afficherReponses(message.reponses, message.getUtilisateur().getId(), message.getUtilisateur().getPseudo(), fil.0.getId(), messageSuppr) }}
-        </div>
-    {% endif %}
-{% endfor %}
+					<div class="responses-container" style="display: none;" data-message-id="{{ message.getIdMessage() }}">
+						{{ macros.afficherReponses(message.reponses, message.getUtilisateur().getId(), message.getUtilisateur().getPseudo(), fil.0.getId(), messageSuppr) }}
+					</div>
+				{% endif %}
+			{% endfor %}
 		</div>
 
 		<!-- Bouton flottant -->
@@ -368,22 +386,26 @@
 			</ul>
 		</nav>
 
-		<script src="JS/thread.js"></script>
-		<script>
-			function confirmerSuppression(idMessage) {
-const confirmationMessage = `Êtes-vous sûr de vouloir supprimer ce message ?`;
-return confirm(confirmationMessage); // Affiche une boîte de confirmation native
-}
-		</script>
-
-		<script src="JS/realtime-messages.js"></script>
-		<script>
-			document.addEventListener('DOMContentLoaded', () => {
-				const realtimeMessages = new RealtimeMessages({{ fil.0.getId() }});
-			});
-		</script>
+		
 
 	</main>
+
+	<script src="JS/thread.js"></script>
+	<script src="JS/realtime-messages.js"></script>
+	<script src="JS/toasts.js"></script>
+	<script>
+		// Pop-up de confirmation de suppression de message
+		function confirmerSuppression(idMessage) {
+			const confirmationMessage = `Êtes-vous sûr de vouloir supprimer ce message ?`;
+			return confirm(confirmationMessage); // Affiche une boîte de confirmation native
+		}
+
+		// Créer l'objet de gestion de la synchronisation des messages en temps réel
+		document.addEventListener('DOMContentLoaded', () => {
+			const realtimeMessages = new RealtimeMessages({{ fil.0.getId() }});
+		});
+	</script>
+
 
 	<style>
 		@media(max-width: 768px) {
@@ -461,3 +483,4 @@ return confirm(confirmationMessage); // Affiche une boîte de confirmation nativ
 	</style>
 
 {% endblock %}
+

--- a/templates/fil.html.twig
+++ b/templates/fil.html.twig
@@ -363,7 +363,7 @@
 
 		
 		<!-- Message d'erreur -->
-		{% if indiqueSuccess is not null %}
+		{% if indiqueSuccess is not null and messageInfos is not null %}
 			<div class="toast-container position-fixed bottom-0 end-0 p-3">
 				<div class="toast align-items-center 
 						{% if indiqueSuccess == false %}

--- a/templates/forum.html.twig
+++ b/templates/forum.html.twig
@@ -58,7 +58,7 @@
 
 
 		<!-- Bouton flottant -->
-		<button class="btn btn-myprimary position-fixed bottom-0 end-0 me-4 mb-5 px-6 d-flex align-items-center justify-content-center" style="border-radius: 50px; white-space: nowrap; min-width: 200px;" id="btnCreaFil" data-bs-toggle="modal" data-bs-target="#nouveauFil">
+		<button class="btn btn-myprimary position-fixed bottom-0 end-0 me-4 mb-5 px-6 d-flex align-items-center justify-content-center" style="border-radius: 50px; white-space: nowrap; min-width: 200px;" id="btnCreaFil" data-bs-toggle="modal" data-bs-target="#nouveauFil" {% if utilisateurConnecte is null %}disabled{% endif 	%}>
 			<i class="bi bi-pencil" style="font-size: 1.3rem; margin-right: 0.2rem;"></i>
 			<span>Nouveau fil</span>
 		</button>


### PR DESCRIPTION
Nouvelles features : 
- Pop-up de succès/erreur
- Suppression de la possibilité (non voulue) de rappeler le serveur en rafraichissant


Nouvelle structure : 
- Utilisation de la variable de session pour passer les messages d'erreurs entre les méthodes afin de ne plus pouvoir répéter les actions (supprimer un message, ajouter un message, etc.) quand on rafraîchit la page du forum

N'hésitez pas à faire des retour ou poser des questions si besoin